### PR TITLE
`.github/workflows/publish.yml` ワークフロー内で `npm install --global npm@latest` していたが、デフォルトでインストールされる npm のバージョンで Trusted publishing を利用できるようになったためこのステップを削除

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,10 +39,5 @@ jobs:
       - name: Node.js/npm のセットアップと依存関係のインストール
         uses: ./.github/actions/setup-npm
 
-      # Note. Trusted publishing を利用するために npm 11.5.1 以上が必要なので
-      # npm をアップデートする（将来的には不要になるはず）
-      - name: npm のアップデート
-        run: npm install --global npm@latest
-
       - name: npm レジストリへ publish
         run: npm publish --provenance


### PR DESCRIPTION
タイトルの通りです。

> [!NOTE]
>
> PR #24 でこのワークフローが導入された時点では `npm install --global npm@latest` を実行しないと Trusted publishing が利用できませんでした。
